### PR TITLE
RTM tries to reconnect if socket closes

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -215,11 +215,11 @@ def handle_message(event):
         print("--------------------------")
 
 # Loop
-if sc.rtm_connect():
+if sc.rtm_connect(auto-reconnect=True):
     update_users()
     update_channels()
     print('Archive bot online. Messages will now be recorded...')
-    while True:
+    while sc.server.connected is True:
         try:
             for event in sc.rtm_read():
                 if event['type'] == 'message':
@@ -234,4 +234,4 @@ if sc.rtm_connect():
             print(traceback.format_exc())
         time.sleep(1)
 else:
-    print("Connection Failed, invalid token?")
+    print(datetime.datetime.now() + "Connection Failed, invalid token?")

--- a/archivebot.py
+++ b/archivebot.py
@@ -215,7 +215,7 @@ def handle_message(event):
         print("--------------------------")
 
 # Loop
-if sc.rtm_connect(auto-reconnect=True):
+if sc.rtm_connect(auto_reconnect=True):
     update_users()
     update_channels()
     print('Archive bot online. Messages will now be recorded...')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six>=1.10.0
-slackclient>=1.0.4
+slackclient>=1.2.0


### PR DESCRIPTION
Was getting this error:
```
SlackConnectionError: Unable to send due to closed RTM websocket

Traceback (most recent call last):
  File "archivebot.py", line 234, in <module>
    for event in sc.rtm_read():
  File "/home/ec2-user/.local/lib/python2.7/site-packages/slackclient/client.py", line 125, in rtm_read
    json_data = self.server.websocket_safe_read()
  File "/home/ec2-user/.local/lib/python2.7/site-packages/slackclient/server.py", line 281, in websocket_safe_read
```

A fix was made in version 1.2.0 of the slack client.  More info here: https://github.com/slackapi/python-slackclient/issues/118#issuecomment-377620713