### PR TITLE
Add flags for specifying database path and bot username

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -11,9 +11,12 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('-d', '--database-path', default='slack.sqlite', help=(
                     'path to the SQLite database. (default = ./slack.sqlite)'))
+parser.add_argument('-b', '--bot-username', default='bot', help=(
+                    'username for the Slack bot user. (default = bot)'))
 args = parser.parse_args()
 
 database_path = args.database_path
+bot_username = args.bot_username
 
 # Connects to the previously created SQL database
 conn = sqlite3.connect(database_path)
@@ -210,7 +213,7 @@ def handle_query(event):
 def handle_message(event):
     if 'text' not in event:
         return
-    if 'username' in event and event['username'] == 'bot':
+    if 'username' in event and event['username'] == bot_username:
         return
 
     try:

--- a/archivebot.py
+++ b/archivebot.py
@@ -7,8 +7,16 @@ import traceback
 from slackclient import SlackClient
 from websocket import WebSocketConnectionClosedException
 
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('-d', '--database-path', default='slack.sqlite', help=(
+                    'path to the SQLite database. (default = ./slack.sqlite)'))
+args = parser.parse_args()
+
+database_path = args.database_path
+
 # Connects to the previously created SQL database
-conn = sqlite3.connect('slack.sqlite')
+conn = sqlite3.connect(database_path)
 cursor = conn.cursor()
 cursor.execute('create table if not exists messages (message text, user text, channel text, timestamp text, UNIQUE(channel, timestamp) ON CONFLICT REPLACE)')
 cursor.execute('create table if not exists users (name text, id text, avatar text, UNIQUE(id) ON CONFLICT REPLACE)')

--- a/export.py
+++ b/export.py
@@ -12,6 +12,9 @@ from six import iteritems
 
 from slackclient import SlackClient
 
+import logging
+logger = logging.getLogger(__name__)
+
 # Used in conjunction with sqlite3 to generate JSON-like format
 def dict_factory(cursor, row):
     d = {}
@@ -44,7 +47,7 @@ time = 0.0
 db_path = sys.argv[1]
 arch_dir = sys.argv[2]
 if not os.path.isdir(arch_dir):
-    os.makedirs(arch_dir) 
+    os.makedirs(arch_dir)
     time = 0.0 # Full export instead of day export
 
 # Uncomment if you need to export entire archive or make this choice
@@ -80,7 +83,7 @@ with open(user_file, 'w') as outfile:
 
 # Define the names associated with each channel id
 ENV = {
-    'channel_id': {}, 
+    'channel_id': {},
     'id_channel': {},
 }
 
@@ -120,11 +123,11 @@ for channel_name in channel_msgs.keys():
         continue
     else:
         update_count += 1
-        print("%s has been updated" % channel_name)
+        logger.info("%s has been updated" % channel_name)
 
     dir = os.path.join(arch_dir, channel_name)
     if "None" in dir:
-        print("Channel not found: %s") %message['channel']
+        logger.warn("Channel not found: %s") %message['channel']
         continue
 
     if not os.path.isdir(dir):
@@ -135,6 +138,6 @@ for channel_name in channel_msgs.keys():
         with open(file, 'w') as outfile:
             json.dump(channel_msgs[channel_name][day], outfile)
             outfile.close()
-print("Updated %s channels" % update_count)
+logger.info("Updated %s channels" % update_count)
 
 connection.close()

--- a/import.py
+++ b/import.py
@@ -4,14 +4,21 @@ import os
 import sqlite3
 import sys
 
-# of slack archive
-directory = sys.argv[1]
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('directory', help=(
+                    'path to the downloaded Slack archive'))
+parser.add_argument('-d', '--database-path', default='slack.sqlite', help=(
+                    'path to the SQLite database. (default = ./slack.sqlite)'))
+args = parser.parse_args()
 
-conn = sqlite3.connect('slack.sqlite')
+conn = sqlite3.connect(args.database_path)
 cursor = conn.cursor()
 cursor.execute('create table if not exists messages (message text, user text, channel text, timestamp text, UNIQUE(channel, timestamp) ON CONFLICT REPLACE)')
 cursor.execute('create table if not exists users (name text, id text, avatar text, UNIQUE(id) ON CONFLICT REPLACE)')
 cursor.execute('create table if not exists channels (name text, id text, UNIQUE(id) ON CONFLICT REPLACE)')
+
+directory = args.directory
 
 print("Importing channels..")
 with open(os.path.join(directory, 'channels.json')) as f:

--- a/import.py
+++ b/import.py
@@ -4,6 +4,9 @@ import os
 import sqlite3
 import sys
 
+import logging
+logger = logging.getLogger(__name__)
+
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('directory', help=(
@@ -20,21 +23,21 @@ cursor.execute('create table if not exists channels (name text, id text, UNIQUE(
 
 directory = args.directory
 
-print("Importing channels..")
+logger.info("Importing channels..")
 with open(os.path.join(directory, 'channels.json')) as f:
     channels = json.load(f)
 args = [(c['name'], c['id']) for c in channels]
 cursor.executemany('INSERT INTO channels VALUES(?,?)', (args))
-print("- Channels imported")
+logger.info("- Channels imported")
 
-print("Importing users..")
+logger.info("Importing users..")
 with open(os.path.join(directory, 'users.json')) as f:
     users = json.load(f)
 args = [(u['name'], u['id'], u['profile']['image_72']) for u in users]
 cursor.executemany('INSERT INTO users VALUES(?,?,?)', (args))
-print("- Users imported")
+logger.info("- Users imported")
 
-print("Importing messages..")
+logger.info("Importing messages..")
 for channel in channels:
     files = glob.glob(os.path.join(directory, channel['name'], '*.json'))
     for file_name in files:
@@ -49,9 +52,9 @@ for channel in channels:
                     message['user'] if 'user' in message else "", channel['id'], message['ts']
                 ))
             else:
-                print("In "+file_name+": An exception occured, message not added to archive.")
+                logger.warn("In "+file_name+": An exception occured, message not added to archive.")
 
         cursor.executemany('INSERT INTO messages VALUES(?, ?, ?, ?)', args)
         conn.commit()
-print("- Messages imported")
-print("Done")
+logger.info("- Messages imported")
+logger.info("Done")


### PR DESCRIPTION
Hello there. I just took a look at this project today, as it seemed to suit our needs for archiving some old chats - kudos! It is quite easy to work with.

I had some needs around further customization so I added options for two items. The defaults are preserved to keep the past behavior.

  - `-d`, `--database-path`: Allows changing where the SQLite DB is loaded from. I run this using Docker volumes so it's nice to be able to change this from the current working directory.
  - `-b`, `--bot-username`: If the username is ever anything but "bot", the bot can't filter out its own messages, because it doens't know its own name. Allow to override; normally when you set up a Slack bot you pick the name.

I could submit these patches in 3 PRs if you want. I didn't initially because I am lazy.