### PR TITLE
Preventing archivebot from responding to its own messages without specifying its name

### DIFF
--- a/archivebot.py
+++ b/archivebot.py
@@ -14,8 +14,6 @@ from websocket import WebSocketConnectionClosedException
 parser = argparse.ArgumentParser()
 parser.add_argument('-d', '--database-path', default='slack.sqlite', help=(
                     'path to the SQLite database. (default = ./slack.sqlite)'))
-parser.add_argument('-b', '--bot-username', default='bot', help=(
-                    'username for the Slack bot user. (default = bot)'))
 parser.add_argument('-l', '--log-level', default='debug', help=(
                     'CRITICAL, ERROR, WARNING, INFO or DEBUG (default = DEBUG)'))
 args = parser.parse_args()
@@ -26,7 +24,6 @@ logging.basicConfig(level=getattr(logging, log_level))
 logger = logging.getLogger(__name__)
 
 database_path = args.database_path
-bot_username = args.bot_username
 
 # Connects to the previously created SQL database
 conn = sqlite3.connect(database_path)
@@ -223,7 +220,7 @@ def handle_query(event):
 def handle_message(event):
     if 'text' not in event:
         return
-    if 'username' in event and event['username'] == bot_username:
+    if 'subtype' in event and event['subtype'] == 'bot_message':
         return
 
     logger.debug(event)

--- a/archivebot.py
+++ b/archivebot.py
@@ -14,6 +14,8 @@ from websocket import WebSocketConnectionClosedException
 parser = argparse.ArgumentParser()
 parser.add_argument('-d', '--database-path', default='slack.sqlite', help=(
                     'path to the SQLite database. (default = ./slack.sqlite)'))
+parser.add_argument('-b', '--bot-username', default='bot', help=(
+                    'username for the Slack bot user. (default = bot)'))
 parser.add_argument('-l', '--log-level', default='debug', help=(
                     'CRITICAL, ERROR, WARNING, INFO or DEBUG (default = DEBUG)'))
 args = parser.parse_args()
@@ -24,6 +26,7 @@ logging.basicConfig(level=getattr(logging, log_level))
 logger = logging.getLogger(__name__)
 
 database_path = args.database_path
+bot_username = args.bot_username
 
 # Connects to the previously created SQL database
 conn = sqlite3.connect(database_path)
@@ -220,7 +223,7 @@ def handle_query(event):
 def handle_message(event):
     if 'text' not in event:
         return
-    if 'subtype' in event and event['subtype'] == 'bot_message':
+    if 'username' in event and event['username'] == bot_username:
         return
 
     logger.debug(event)


### PR DESCRIPTION
Hi,
while specifying the bot's name certainly works, I think it's unnecessarily complicated for users (especially as it is not mentioned in the README). The same behaviour can be accomplished by simply ignoring all messages with subtype 'bot_message'.

Sorry for the reverted commit in the PR, but I'm somewhat new to this and didn't want to present you with a wall of changes, due to deleted carriage returns.