### PR TITLE
Fix issue #9

### DIFF
--- a/import.py
+++ b/import.py
@@ -46,7 +46,7 @@ logger.info("Importing messages..")
 for channel in channels:
     files = glob.glob(os.path.join(directory, channel['name'], '*.json'))
     for file_name in files:
-        with open(file_name) as f:
+        with open(file_name, encoding='utf8') as f:
             messages = json.load(f)
 
         args = []


### PR DESCRIPTION
As mentioned in issue #9 , this change implements the described solution to the described problem.
All credit should go to @dreitznercee .

This is because on Windows the default encoding of open() may not be UTF8.
See the following for more info:
https://stackoverflow.com/questions/36303919/python-3-0-open-default-encoding
https://docs.python.org/3.7/library/functions.html#open