### PR TITLE
Support socket mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ further back than 10,000 messages.
 
 1. Permission to install new apps to your Slack workspace.
 2. python3
-3. A publicly accessible URL to serve the bot from. (Slack recommends using [ngrok](https://ngrok.com/) to get around this.)
+3. A publicly accessible URL to serve the bot from. (Slack recommends using [ngrok](https://ngrok.com/) to get around this.) Not needed when using socket mode.
 
 ## Installation
 
@@ -35,6 +35,8 @@ on the directory.  For example:
   - `groups:read` (if you want to archive/search private channels)
   - `im:history`
   - `users:read`
+
+- For socket mode, skip to [socket mode](#socket-mode)
 
 5. Start slack-archive-bot with:
 
@@ -101,6 +103,12 @@ to the query.  The full usage is:
 
 - Follow the installation steps above to create a new slack app with all of the required permissions and event subscriptions.
 - The biggest change in requirements with the new version is the move from the [Real Time Messaging API](https://api.slack.com/rtm) to the [Events API](https://api.slack.com/apis/connections/events-api) which necessitates having a publicly-accessible url that Slack can send events to. If you are unable to serve a public endpoint, you can use [ngrok](https://ngrok.com/).
+
+## Socket mode
+
+To run the bot in socket mode, go to the app's "Socket Mode" page and enable it. Then add the app level token you got to environment variables.
+
+Finally, run the bot with "-s" or "--socket" option.
 
 ## Contributing
 

--- a/archivebot.py
+++ b/archivebot.py
@@ -358,12 +358,12 @@ def init():
 
 
 def main():
+    init()
     # Start the development server
     if cmd_args.socket:
         handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
         handler.start()
     else:
-        init()
         app.start(port=port)
 
 

--- a/archivebot.py
+++ b/archivebot.py
@@ -4,6 +4,7 @@ import os
 import traceback
 
 from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 from utils import db_connect, migrate_db
 
@@ -22,6 +23,12 @@ parser.add_argument(
 )
 parser.add_argument(
     "-p", "--port", default=3333, help="Port to serve on. (default = 3333)"
+)
+parser.add_argument(
+    "-s",
+    "--socket",
+    action="store_true",
+    help=("enable socket mode")
 )
 cmd_args, unknown = parser.parse_known_args()
 
@@ -351,10 +358,13 @@ def init():
 
 
 def main():
-    init()
-
     # Start the development server
-    app.start(port=port)
+    if cmd_args.socket:
+        handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
+        handler.start()
+    else:
+        init()
+        app.start(port=port)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six>=1.10.0
-slack-bolt==1.2.1 
+slack-bolt==1.14.3 


### PR DESCRIPTION
Add support for socket mode in newer versions of bolt, which eliminates the need of a running http server.

It can be enabled through the command line switch "-s" or "--socket".